### PR TITLE
I think .mag is a property, so generates 'float not callable' error.

### DIFF
--- a/vpython-packaging/vpython/vpython.py
+++ b/vpython-packaging/vpython/vpython.py
@@ -947,7 +947,7 @@ class standardAttributes(baseObj):
         self.addattr('pos')
 
     def _on_axis_change(self):
-        self._size.x = self._axis.mag()
+        self._size.x = self._axis.mag
         self.addattr('axis')
 
     def _on_up_change(self):

--- a/vpython.py
+++ b/vpython.py
@@ -947,7 +947,7 @@ class standardAttributes(baseObj):
         self.addattr('pos')
 
     def _on_axis_change(self):
-        self._size.x = self._axis.mag()
+        self._size.x = self._axis.mag
         self.addattr('axis')
 
     def _on_up_change(self):


### PR DESCRIPTION
I was trying to port one of my QM programs to vpython-jupiter and hit this error.
