### PR TITLE
Please do NOT merge yet: Change setup.py to use cython only if cython is installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,14 @@ except ImportError:
     use_setuptools()
     from setuptools import setup
 
-from Cython.Build import cythonize
+from distutils.extension import Extension
+
+try:
+    from Cython.Build import cythonize
+    USE_CYTHON = True
+    extensions = cythonize('vpython/cyvector.pyx')
+except ImportError:
+    extensions = [Extension('vpython.cyvector', ['vpython/cyvector.c'])]
 
 import versioneer
 
@@ -34,7 +41,7 @@ setup(
           'Topic :: Multimedia :: Graphics :: 3D Rendering',
           'Topic :: Scientific/Engineering :: Visualization',
     ],
-    ext_modules = cythonize("vpython/cyvector.pyx"),
+    ext_modules=extensions,
     install_requires=['jupyter', 'vpnotebook'],
     package_data={'vpython': ['data/*']},
 )


### PR DESCRIPTION
This PR modifies setup.py so that Cython is used during installation only if Cython is installed. If it is not, the cythonized C file generated when the source distribution is made is built as a standard C extension.

This will likely have no impact on mac or Windows users because we have binary wheels for those, and no effect on conda users.

It will simplify installation for Linux users.

I would like to add a test on travis that makes sure the built distribution can be built on linux without error before this gets merged.