### PR TITLE
Specify encoding when reading glow.min.js

### DIFF
--- a/vpython/gs_version.py
+++ b/vpython/gs_version.py
@@ -1,5 +1,6 @@
 import os
 import re
+from io import open
 
 
 def glowscript_version():
@@ -10,7 +11,7 @@ def glowscript_version():
     this_dir = os.path.dirname(os.path.abspath(__file__))
     glowscript_lib = os.path.join(this_dir, 'vpython_libraries', 'glow.min.js')
 
-    with open(glowscript_lib, 'r') as f:
+    with open(glowscript_lib, 'r', encoding='UTF-8') as f:
         glow_contents = f.read()
 
     matches = re.search(r'glowscript={version:"(.*?)"}', glow_contents)


### PR DESCRIPTION
This fixes the installation problem on Windows/python 3. I've tried the fix on python 2 and 3 on Windows.