### PR TITLE
Update binder button to point to beta.binder.org 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ controls available to zoom and rotate the camera:
          On a two-button mouse, middle is left + right.
     Touch screen: pinch/extend to zoom, swipe or two-finger rotate.
 
-Run example VPython programs: [![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/repo/BruceSherwood/vpython-jupyter)
+Run example VPython programs: [![Binder](http://mybinder.org/badge.svg)](http://beta.mybinder.org/v2/gh/BruceSherwood/vpython-jupyter/7.0.3?filename=index.ipynb)
 
 ## vpython build status (for the vpython developers)
 


### PR DESCRIPTION
The old binder service has died, replaced by a newer version at beta.mybinder.org. This updates the URL and has it build the 7.0.3 release of vpython-jupyter (rather than whatever is the latest commit). Closes #30.