### PR TITLE
Fix binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ controls available to zoom and rotate the camera:
 
 Currently, to re-run a VPython program you need to click the circular arrow icon to "restart the kernel" and then click the red-highlighted button, then click in the first cell, then click the run icon. Alternatively, if you insert "scene = canvas()" at the start of your program, you can rerun the program without restarting the kernel.
 
-Run example VPython programs: [![Binder](http://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/BruceSherwood/vpython-jupyter/7.1.2?filepath=index.ipynb)
+Run example VPython programs: [![Binder](http://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/BruceSherwood/vpython-jupyter/master?filepath=index.ipynb)
 
 ## vpython build status (for the vpython developers)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+Cython
 vpnotebook
 vpython


### PR DESCRIPTION
This fixes #54 by adding Cython to the requirements for binder, and by changing the binder link so it builds from master instead of a specific release.