### PR TITLE
Run websocket server in separate thread/event loop

### DIFF
--- a/vpython/test/test_namespace.py
+++ b/vpython/test/test_namespace.py
@@ -137,7 +137,9 @@ API_NAMES = [
     'trunc',
     'vec',
     'vector',
+    'version',
     'vertex',
+    'winput',
     'wtext'
 ]
 


### PR DESCRIPTION
BECAUSE THEN WE CAN SPYDER AT LAST!!!!!!!

Sorry for the shouting, I was glad this finally works. When there is no notebook this starts the event loop and the websocket server in a separate thread. I want to thank @jcoady -- following what he did in the notebook case using tornado was essential. 

Fixes #80 