### PR TITLE
Simplify notebook logic

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,12 +26,6 @@ environment:
     - TARGET_ARCH: "x64"
       CONDA_PY: "3.5"
       CONDA_INSTALL_LOCN: "C:\\Miniconda35-x64"
-    - TARGET_ARCH: "x64"
-      CONDA_PY: "3.4"
-      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
-    - TARGET_ARCH: "x64"
-      CONDA_PY: "2.7"
-      CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
 
     # 32-bit builds
     - TARGET_ARCH: "x86"
@@ -40,12 +34,6 @@ environment:
     - TARGET_ARCH: "x86"
       CONDA_PY: "3.5"
       CONDA_INSTALL_LOCN: "C:\\Miniconda35"
-    - TARGET_ARCH: "x86"
-      CONDA_PY: "3.4"
-      CONDA_INSTALL_LOCN: "C:\\Miniconda36"
-    - TARGET_ARCH: "x86"
-      CONDA_PY: "2.7"
-      CONDA_INSTALL_LOCN: "C:\\Miniconda"
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ except ImportError:
 
 import versioneer
 
-install_requires = ['jupyter', 'vpnotebook', 'numpy', 'ipykernel<5']
+install_requires = ['jupyter', 'vpnotebook', 'numpy', 'ipykernel']
 
 if sys.version_info.major == 3 and sys.version_info.minor >= 5:
     install_requires.append('autobahn')

--- a/vpython/rate_control.py
+++ b/vpython/rate_control.py
@@ -247,22 +247,13 @@ class _RateKeeper2(RateKeeper):
         if _isnotebook:
             if not self._sender:
                 self._sender = message_send_wrapper()
-            if ((IPython.__version__ >= '7.0.0') or
-                    (ipykernel.__version__ >= '5.0.0')):
-                while ws_queue.qsize() > 0:
-                    data = ws_queue.get()
-                    d = json.loads(data)  # update_canvas info
-                    for m in d:
-                        # Must send events one at a time to GW.handle_msg because bound events need the loop code:
-                        msg = {'content':{'data':[m]}} # message format used by notebook
-                        self._sender(msg)
-
-            elif IPython.__version__ >= '3.0.0':
-                kernel = IPython.get_ipython().kernel
-                parent = kernel._parent_header
-                ident = kernel._parent_ident
-                kernel.do_one_iteration()
-                kernel.set_parent(ident, parent)
+            while ws_queue.qsize() > 0:
+                data = ws_queue.get()
+                d = json.loads(data)  # update_canvas info
+                for m in d:
+                    # Must send events one at a time to GW.handle_msg because bound events need the loop code:
+                    msg = {'content':{'data':[m]}} # message format used by notebook
+                    self._sender(msg)
 
     def __call__(self, N): # rate(N) calls this function
         self.rval = N

--- a/vpython/with_notebook.py
+++ b/vpython/with_notebook.py
@@ -134,7 +134,7 @@ def start_server():
     tornado.ioloop.IOLoop.instance().start()
 
 
-if (ipykernel.__version__ >= '5.0.0'):
+if (ipykernel.__version__ >= '4.0.0'):
 	from threading import Thread
 	t = Thread(target=start_server, args=())
 	t.start()
@@ -147,7 +147,7 @@ else:
 baseObj.trigger()  # start the trigger ping-pong process
 
 if IPython.__version__ >= '4.0.0':
-    if (ipykernel.__version__ >= '5.0.0'):
+    if (ipykernel.__version__ >= '4.0.0'):
         async def wsperiodic():
             while True:
                 if ws_queue.qsize() > 0:

--- a/vpython/with_notebook.py
+++ b/vpython/with_notebook.py
@@ -66,14 +66,8 @@ if 'nbextensions' in os.listdir(jd):
         transfer = (v != __version__) # need not transfer files to nbextensions if correct version's files already there
 
 if transfer:
-    if IPython.__version__ >= '4.0.0' :
-        notebook.nbextensions.install_nbextension(path = package_dir+"/vpython_data",overwrite = True,user = True,verbose = 0)
-        notebook.nbextensions.install_nbextension(path = package_dir+"/vpython_libraries",overwrite = True,user = True,verbose = 0)
-    elif IPython.__version__ >= '3.0.0' :
-        IPython.html.nbextensions.install_nbextension(path = package_dir+"/vpython_data",overwrite = True,user = True,verbose = 0)
-        IPython.html.nbextensions.install_nbextension(path = package_dir+"/vpython_libraries",overwrite = True,user = True,verbose = 0)
-    else:
-        IPython.html.nbextensions.install_nbextension(files = [package_dir+"/vpython_data", package_dir+"/vpython_libraries"],overwrite=True,verbose=0)
+    notebook.nbextensions.install_nbextension(path = package_dir+"/vpython_data",overwrite = True,user = True,verbose = 0)
+    notebook.nbextensions.install_nbextension(path = package_dir+"/vpython_libraries",overwrite = True,user = True,verbose = 0)
 
     # Wait for files to be transferred to nbextensions:
     libready = False

--- a/vpython/with_notebook.py
+++ b/vpython/with_notebook.py
@@ -114,7 +114,7 @@ class WSHandler(tornado.websocket.WebSocketHandler):
         ws_queue.put(message)
 
     def on_close(self):
-        self.stopTornado()
+        self.stop_tornado()
 
     def stop_tornado(self):
         ioloop = tornado.ioloop.IOLoop.instance()


### PR DESCRIPTION
This removes version checks for ipython and ipykernel. I will set a minimum version for IPython in the setup.py to 4 (ipykernel started at version 4 so no need for a minimum version for that).

Fixes #73 (was bug)

Issues below were compatibility checks:

Fixes #74 
Fixes #75 
Fixes #76 
Fixes #77