### PR TITLE
Make sure installation succeeds even if there is no compiler

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ install_requires = ['jupyter', 'vpnotebook', 'numpy', 'ipykernel']
 if sys.version_info.major == 3 and sys.version_info.minor >= 5:
     install_requires.append('autobahn')
 
-setup(
+setup_args = dict(
     name='vpython',
     packages=['vpython'],
     version=versioneer.get_version(),
@@ -54,3 +54,14 @@ setup(
                               'vpython_libraries/*',
                               'vpython_libraries/images/*']},
 )
+
+try:
+    setup(**setup_args)
+except SystemExit as e:
+    print('Compiled version of vector failed with:')
+    print(e)
+    print('***** Using pure python version of vector, which is slower.')
+
+    # Do not try to build the extension
+    del setup_args['ext_modules']
+    setup(**setup_args)


### PR DESCRIPTION
This modifies setup.py to try building the cython vector first and, if that fails, installs without building that extension. 

There are at least a couple of different ways that the failure can happen: user has no compiler installed (the usual case on windows) or the compiler is misconfigured, or you are building from source and forget to install cython :).

Ready to merge once the tests pass.