### PR TITLE
Remove old python builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,9 @@ env:
         - CONDA_INSTALL_LOCN="${HOME}/miniconda"
         - TWINE_USERNAME="mwcraig"
     matrix:
-        - CONDA_PY=2.7
-        - CONDA_PY=3.4
         - CONDA_PY=3.5
         - CONDA_PY=3.6
+        - CONDA_PY=3.7
 
 install:
     # Install and set up miniconda.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,9 @@ environment:
     # the appveyor setup only sets up the SDK once, so separate by python
     # versions.
     - TARGET_ARCH: "x64"
+      CONDA_PY: "3.7"
+      CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
+    - TARGET_ARCH: "x64"
       CONDA_PY: "3.6"
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
     - TARGET_ARCH: "x64"
@@ -28,6 +31,9 @@ environment:
       CONDA_INSTALL_LOCN: "C:\\Miniconda35-x64"
 
     # 32-bit builds
+    - TARGET_ARCH: "x86"
+      CONDA_PY: "3.7"
+      CONDA_INSTALL_LOCN: "C:\\Miniconda37"
     - TARGET_ARCH: "x86"
       CONDA_PY: "3.6"
       CONDA_INSTALL_LOCN: "C:\\Miniconda36"
@@ -41,21 +47,16 @@ platform:
     - x64
 
 install:
-    # Clone  to get the script for setting up Windows build environment and the script for installing conda.
-    - cmd: git clone https://github.com/pelson/Obvious-CI.git
-
-    - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\Scripts;%PATH%
-
+    - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     # Gets us vpnotebook
     - cmd: conda config --add channels vpython
 
     - cmd: conda config --set always_yes true
     - cmd: conda update --quiet conda
-    - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 
 
-    - cmd: conda install --quiet jinja2 conda-build anaconda-client cython
-    - cmd: conda install --quiet wheel
+
+    - cmd: conda install --quiet jinja2 conda-build anaconda-client cython wheel
 
     # These installs are needed on windows but not other platforms.
     - cmd: conda install --quiet patch psutil
@@ -68,7 +69,7 @@ build: off
 
 test_script:
     # Not much of a real test yet, just try to build myself...
-    - "%CMD_IN_ENV% conda build --quiet vpython.recipe"
+    - conda build --quiet vpython.recipe
     # ...and build a wheel, in the test environment so we have the right
     # python version.
     # Write the output file location to a file...
@@ -81,7 +82,7 @@ test_script:
     - for %%F in (%BUILT_PACKAGE%) do set dirname=%%~dpF
     - echo %dirname%
     - activate wheel-build
-    - "%CMD_IN_ENV% python setup.py bdist_wheel"
+    - python setup.py bdist_wheel"
     - deactivate
 
 on_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,8 @@ environment:
   # Install appropriate conda here based on TARGET_ARCH
   CONDA_INSTALL_LOCN: "C:\\conda"
 
-  # Need this to set up compilation on Windows.
-  CMD_IN_ENV: cmd /E:ON /V:ON /C Obvious-CI\scripts\obvci_appveyor_python_build_env.cmd
+  # These installs are needed on windows but not other platforms.
+  INSTALL_ON_WINDOWS: "patch psutil"
 
   BINSTAR_TOKEN:
     secure: eSsu75dpqknmh2NnrfPASDSvzojBRSyoyW9ZdF5VauukhWxmYHbW8E5UE2ZmYnxT
@@ -56,10 +56,7 @@ install:
 
 
 
-    - cmd: conda install --quiet jinja2 conda-build anaconda-client cython wheel
-
-    # These installs are needed on windows but not other platforms.
-    - cmd: conda install --quiet patch psutil
+    - cmd: conda install --quiet jinja2 conda-build anaconda-client cython wheel %INSTALL_ON_WINDOWS%
 
     - conda create --quiet -n wheel-build python=%CONDA_PY% wheel cython
     - conda info -a


### PR DESCRIPTION
This updates the python versions we build for to 3.5, 3.6 and 3.7.

This should not be merged before both appveyor and travis complete to make sure it actually works...

Fixes #96