### PR TITLE
Add ability to upload to special label if tag is a pre-release

### DIFF
--- a/.ci-support/upload_label.py
+++ b/.ci-support/upload_label.py
@@ -1,0 +1,25 @@
+import os
+
+travis_tag = os.getenv('TRAVIS_TAG')
+appveyor_tag = os.getenv('APPVEYOR_REPO_TAG')
+
+
+def generate_label(version):
+    dev_names = ['dev', 'alpha', 'beta', 'rc']
+
+    is_dev = any(name in version for name in dev_names)
+
+    # Output is the name of the label to which the package should be
+    # uploaded on anaconda.org
+    if is_dev:
+        print('pre-release')
+    else:
+        print('main')
+
+
+if travis_tag:
+    generate_label(travis_tag)
+elif appveyor_tag:
+    generate_label(appveyor_tag)
+else:
+    print('main')

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,10 +79,12 @@ script:
 after_success:
     - echo $TRAVIS_TAG
     - git branch --contains $TRAVIS_TAG
+    - upload_label=$(python .ci-support/upload_label.py)
     - if [[ "$TRAVIS_TAG" ]]; then upload_build="true"; else upload_build=; fi
     - echo $upload_build
+    - echo "Uploading to $upload_label"
     # If this build is because of a tag, upload the build if it succeeds.
-    - if [ -n "$upload_build" ]; then anaconda -t $BINSTAR_TOKEN upload -u vpython $CONDA_PACKAGE; fi
+    - if [ -n "$upload_build" ]; then anaconda -t $BINSTAR_TOKEN upload -u vpython -l $upload_label $CONDA_PACKAGE; fi
     # Upload wheel builds to pypi instead of relying on travis deploy because that
     # does not seem to continue gracefully if a distribution already exists,
     # and in most of the jobs a source distribution will already have been

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -87,7 +87,7 @@ on_success:
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - set upload_builds=
     - if "%APPVEYOR_REPO_TAG%"=="true" set upload_builds=1
-    - python .ci-support\upload-label.py > label.txt
+    - python .ci-support\upload_label.py > label.txt
     - set /P UPLOAD_LABEL=<label.txt
     - echo %UPLOAD_LABEL%
     # If this build is because of a tag on master make the conda package and upload it.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -87,7 +87,10 @@ on_success:
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - set upload_builds=
     - if "%APPVEYOR_REPO_TAG%"=="true" set upload_builds=1
+    - python .ci-support\upload-label.py > label.txt
+    - set /P UPLOAD_LABEL=<label.txt
+    - echo %UPLOAD_LABEL%
     # If this build is because of a tag on master make the conda package and upload it.
-    - cmd: if defined upload_builds anaconda -t %BINSTAR_TOKEN% upload -u vpython %BUILT_PACKAGE%
+    - cmd: if defined upload_builds anaconda -t %BINSTAR_TOKEN% upload -u vpython -l %UPLOAD_LABEL% %BUILT_PACKAGE%
     - cmd: pip install twine
     - cmd: if defined upload_builds twine upload -u %PYPI_USER% -p %PYPI_PASSWORD% dist\*


### PR DESCRIPTION
This (hopefully) adds the ability to upload test releases (alpha, beta, whatever) to a less visible place on anaconda. 

The goal is to make it easy for us to create and test possible releases while ensuring that the typical user never installs a pre-release by accident. pip has this built in to some extent -- if a release has text like "alpha" or "beta" in the name of the release then pip will not install it unless one uses a special flag (`--pre`).

Conda doesn't have something equivalent but does have the concept of labels. Packages by default are uploaded to the "main" channel; when a user does `conda install -c vpython vpython` then conda checks the main channel for the user vpython on anaconda.org. One can have other labels; this adds one called `pre-release`. 

We can fairly easily install those by including the label but ordinary users won't have any reason to do that.