### PR TITLE
Improve the user experience in spyder

### DIFF
--- a/vpython/__init__.py
+++ b/vpython/__init__.py
@@ -9,7 +9,7 @@ del glowscript_version
 #  __gs_version__ exist before importing vpython, which itself imports
 # both of those.
 
-from ._notebook_helpers import _isnotebook
+from ._notebook_helpers import _isnotebook, __is_spyder
 import platform
 __p = platform.python_version()
 
@@ -51,3 +51,10 @@ except NameError:
 from math import *
 from numpy import arange
 from random import random
+
+if __is_spyder():
+    from ._notebook_helpers import _spyder_run_setting_is_correct
+    if not _spyder_run_setting_is_correct():
+        print('** Please set spyder preference Run to '
+              '"Execute in a dedicated console" for the best '
+              'vpython experience. **')

--- a/vpython/__init__.py
+++ b/vpython/__init__.py
@@ -53,8 +53,5 @@ from numpy import arange
 from random import random
 
 if __is_spyder():
-    from ._notebook_helpers import _spyder_run_setting_is_correct
-    if not _spyder_run_setting_is_correct():
-        print('** Please set spyder preference Run to '
-              '"Execute in a dedicated console" for the best '
-              'vpython experience. **')
+    from ._notebook_helpers import _warn_if_spyder_settings_wrong
+    _warn_if_spyder_settings_wrong()

--- a/vpython/_notebook_helpers.py
+++ b/vpython/_notebook_helpers.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 
 def __is_spyder():
@@ -15,6 +16,12 @@ def _warn_if_spyder_settings_wrong():
         print('\x1b[1;31m**** Please set spyder preference Run to '
               '"Execute in a dedicated console" for the best '
               'vpython experience. ****\x1b[0m')
+
+
+def _undo_vpython_import_in_spyder():
+    for modname, module in list(sys.modules.items()):
+        if modname.startswith('vpython'):
+            del sys.modules[modname]
 
 
 def __checkisnotebook():

--- a/vpython/_notebook_helpers.py
+++ b/vpython/_notebook_helpers.py
@@ -1,12 +1,21 @@
 import os
 
 
+def __is_spyder():
+    return any('SPYDER' in name for name in os.environ)
+
+
+def _spyder_run_setting_is_correct():
+    from spyder.config.main import CONF
+    return CONF['run']['default/interpreter/dedicated']
+
+
 def __checkisnotebook():
     """
     Check whether we are running in a notebook or not
     """
     try:
-        if any('SPYDER' in name for name in os.environ):
+        if __is_spyder():
             return False    # Spyder detected so return False
         shell = get_ipython().__class__.__name__
         if shell == 'ZMQInteractiveShell':  # Jupyter notebook or qtconsole?
@@ -21,3 +30,4 @@ def __checkisnotebook():
 
 # IMPORTANT NOTE: this is evaluated ONCE the first time this is imported.
 _isnotebook = __checkisnotebook()
+_in_spyder = __is_spyder()

--- a/vpython/_notebook_helpers.py
+++ b/vpython/_notebook_helpers.py
@@ -10,6 +10,13 @@ def _spyder_run_setting_is_correct():
     return CONF['run']['default/interpreter/dedicated']
 
 
+def _warn_if_spyder_settings_wrong():
+    if not _spyder_run_setting_is_correct():
+        print('\x1b[1;31m**** Please set spyder preference Run to '
+              '"Execute in a dedicated console" for the best '
+              'vpython experience. ****\x1b[0m')
+
+
 def __checkisnotebook():
     """
     Check whether we are running in a notebook or not

--- a/vpython/no_notebook.py
+++ b/vpython/no_notebook.py
@@ -1,5 +1,5 @@
 from .vpython import GlowWidget, baseObj, vector, canvas
-from ._notebook_helpers import _in_spyder
+from ._notebook_helpers import _in_spyder, _undo_vpython_import_in_spyder
 
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import os
@@ -192,12 +192,14 @@ class WSserver(WebSocketServerProtocol):
 
         self.connection = None
 
+        # We r done serving, let everyone else know...
         websocketserving = False
 
+        # The cleanest way to get a fresh browser tab going in spyder
+        # is to force vpython to be reimported each time the code is run.
         if _in_spyder:
-            for modname, module in list(sys.modules.items()):
-                if modname.startswith('vpython'):
-                    del sys.modules[modname]
+            _undo_vpython_import_in_spyder()
+
         # We want to exit, but the main thread is running.
         # Only the main thread can properly call sys.exit, so have a signal
         # handler call it on the main thread's behalf.

--- a/vpython/no_notebook.py
+++ b/vpython/no_notebook.py
@@ -265,31 +265,6 @@ __t = threading.Thread(target=start_websocket_server)
 __t.start()
 
 
-def ensure_websocket_server():
-    global __SOCKET_PORT, GW
-    if not websocketserving:
-        __SOCKET_PORT = find_free_port()
-        # Put the websocket server in a separate thread running its own event loop.
-        # That works even if some other program (e.g. spyder) already running an
-        # async event loop.
-        __t = threading.Thread(target=start_websocket_server)
-        __t.start()
-    # Update the html with which we respond to include the new socket port
-    glowcomm_with_socket_port(__SOCKET_PORT)
-    print(__SOCKET_PORT)
-    scene = canvas()
-    # This hits our new websocket server which should start it running
-    GW = GlowWidget()
-
-    # If we arrived in this function then the browser tab has been closed so
-    # reopen it.
-    _webbrowser.open('http://localhost:{}'.format(__HTTP_PORT))
-
-    while not websocketserving:
-        rate(60)
-
-
-
 def stop_server():
     """Shuts down all threads and exits cleanly."""
     global __server

--- a/vpython/vpython.py
+++ b/vpython/vpython.py
@@ -223,6 +223,11 @@ class baseObj(object):
             else:
                 from .no_notebook import _
             baseObj._view_constructed = True
+        elif baseObj._view_constructed and not _isnotebook and not baseObj._canvas_constructing:
+            from .no_notebook import still_serving, ensure_websocket_server
+            if not still_serving():
+                print("Dang navvit me no has server!!!")
+                ensure_websocket_server()
 
         self.idx = baseObj.objCnt   ## an integer
         self.object_registry[self.idx] = self

--- a/vpython/vpython.py
+++ b/vpython/vpython.py
@@ -223,11 +223,6 @@ class baseObj(object):
             else:
                 from .no_notebook import _
             baseObj._view_constructed = True
-        elif baseObj._view_constructed and not _isnotebook and not baseObj._canvas_constructing:
-            from .no_notebook import still_serving, ensure_websocket_server
-            if not still_serving():
-                print("Dang navvit me no has server!!!")
-                ensure_websocket_server()
 
         self.idx = baseObj.objCnt   ## an integer
         self.object_registry[self.idx] = self


### PR DESCRIPTION
When merged, this will become alpha4.

Users should set the spyder preference "Run" to "Execute in a dedicated console" to avoid having multiple vpython programs run in the same view.

Each program the user runs opens in a separate browser tab. That is unavoidable. Ideally, t user would close those tabs between runs.

With this PR:

- There is a message printed when vpython is imported if the user has the wrong Run setting. Screenshot is below.
- When the browser tab is closed and the user is running in spyder, magic is done behind the scenes to force vpython to be re-imported the next time the code is run.
- Pushing run multiple times on the same program without closing the browser tab results in displaying the same things multiple times (once for each time you hit run). Not sure I can fix that.

Screenshot of warning message printed in spyder console:

<img width="839" alt="screen shot 2019-01-24 at 9 03 59 am" src="https://user-images.githubusercontent.com/1147167/51687731-c4572600-1fb8-11e9-804c-973d1b592bad.png">
