### PR TITLE
Fix vector operators

### DIFF
--- a/vpython/cyvector.pyx
+++ b/vpython/cyvector.pyx
@@ -62,23 +62,26 @@ cdef class vector(object):
         return '<{:.6g}, {:.6g}, {:.6g}>'.format(self._x, self._y, self._z)
 
     def __add__(self,other):
-        return vector(self._x + other._x, self._y + other._y, self._z + other._z)
+        if type(other) is vector:
+            return vector(self._x + other._x, self._y + other._y, self._z + other._z)
+        return NotImplemented
 
     def __truediv__(self, other): # Python 3, or Python 2 + future division
         if isinstance(other, (int, float)):
             return vector(self._x / other, self._y / other, self._z / other)
-        raise TypeError('a vector can only be divided by a scalar')
+        return NotImplemented
 
     def __sub__(self,other):
-        return vector(self._x - other._x, self._y - other._y, self._z - other._z)
+        if type(other) is vector:
+            return vector(self._x - other._x, self._y - other._y, self._z - other._z)
+        return NotImplemented
 
     def __mul__(self, other):  ## in cython order of arguments is arbitrary, rmul doesn't exist
         if isinstance(other, (int, float)):
             return vector(self._x * other, self._y * other, self._z * other)
         elif isinstance(self, (int, float)):
             return vector(self * other._x, self * other._y, self * other._z)
-        else:
-            raise TypeError('a vector can only be multiplied by a scalar', self, other)
+        return NotImplemented
 
     def __eq__(self,other):
         if type(self) is vector and type(other) is vector:

--- a/vpython/vector.py
+++ b/vpython/vector.py
@@ -53,29 +53,30 @@ class vector(object):
     def __repr__(self):
         return '<{:.6g}, {:.6g}, {:.6g}>'.format(self._x, self._y, self._z)
 
-    def __add__(self,other):
-        return vector(self._x + other._x, self._y + other._y, self._z + other._z)
+    def __add__(self, other):
+        if type(other) is vector:
+            return vector(self._x + other._x, self._y + other._y, self._z + other._z)
+        return NotImplemented
 
-    def __sub__(self,other):
-        return vector(self._x - other._x, self._y - other._y, self._z - other._z)
+    def __sub__(self, other):
+        if type(other) is vector:
+            return vector(self._x - other._x, self._y - other._y, self._z - other._z)
+        return NotImplemented
 
     def __truediv__(self, other): # used by Python 3, and by Python 2 in the presence of __future__ division
-        try:
+        if isinstance(other, (float, int)):
             return vector(self._x / other, self._y / other, self._z / other)
-        except:
-            raise TypeError('a vector can only be divided by a scalar')
+        return NotImplemented
 
     def __mul__(self, other):
-        try:
+        if isinstance(other, (float, int)):
             return vector(self._x * other, self._y * other, self._z * other)
-        except:
-            raise TypeError('a vector can only be multiplied by a scalar')
+        return NotImplemented
 
     def __rmul__(self, other):
-        try:
+        if isinstance(other, (float, int)):
             return vector(self._x * other, self._y * other, self._z * other)
-        except:
-            raise TypeError('a vector can only be multiplied by a scalar')
+        return NotImplemented
 
     def __eq__(self,other):
         if type(self) is vector and type(other) is vector:


### PR DESCRIPTION
The current Implementation of vectors raises an exception in `__mul__` when you try to operate on a non-vector type.
This can be quite annoying, because even if for example `Quaternion` implements `__rmul__` it will never be called when the vector is on the left side of the equation and instead error out.
Furthermore: https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types specifies that (some) operators should return `NotImplemented`.
```python
# Does not work, should work
v = vector(0, 0, 0) * quaternion(0, 0, 0, 0)
# Does work, should work
v = quaternion(0,0,0,0) * vector(0,0,0,0)
```

Both the python and cython implementations have been tested (existing physics project that makes heavy use of vectors didn't break)