### PR TITLE
Fix link to bounce jupyter demo

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "[Binary star](Demos/BinaryStar.ipynb): two stars orbit each other\n",
     "\n",
-    "[Bounce](Demos/Bounce.ipynb): a ball bounces in a 3D box\n",
+    "[Bounce](Demos/Bounce-VPython.ipynb): a ball bounces in a 3D box\n",
     "\n",
     "[Local moving lights](Demos/BoxLightTest.ipynb): local lights moving around the scene\n",
     "\n",


### PR DESCRIPTION
The bounce jupyter demo in the mybinder examples directs you to a ["404 Not Found" page](https://hub.mybinder.org/user/brucesherwood-vpython-jupyter-jzwzt529/notebooks/Demos/Bounce.ipynb)

It seems the notebook file has been renamed from `Demos/Bounce,ipynb` to `Demos/Bounce-VPython.ipynb`. Updating the link to reflect this fixes the problem: https://hub.mybinder.org/user/brucesherwood-vpython-jupyter-jzwzt529/notebooks/Demos/Bounce-VPython.ipynb